### PR TITLE
Makefile: Make compatible with cross-compile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,14 @@
+# Cross-compile compatible module makefile based on other Kernel modules
+# SPDX-License-Identifier: GPL-2.0
 
 obj-m += st25dv.o
+SRC := $(shell pwd)
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules
+
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules_install
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) clean


### PR DESCRIPTION
Allow specifying a KERNEL_SRC environment variable where the
kernel source can be found for cross compiling.