### PR TITLE
fix: add missing delay after last written chunk

### DIFF
--- a/src/st25dv.c
+++ b/src/st25dv.c
@@ -196,6 +196,24 @@ retry_:
 		cur_buf_off += to_write;
 	}
 
+	//ACK Polling after last sent data chunk
+	nack = 0;
+	while (true) {
+		if(nack > MAX_TRY){
+			mutex_unlock(data->update_lock);
+			//printk(KERN_ERR "st25dv: ERROR too many NACKS. Device seems to be busy.\n");
+			return r_size;
+		}
+
+		r_size = i2c_master_send(client, "", 0);
+		if(r_size == 0) {
+			break;
+		} else {
+			nack++;
+			mdelay(5);
+		}
+	}
+
 	mutex_unlock(data->update_lock);
 	//printk(KERN_WARNING "st25dv: %d byte writes.\n",count);
 


### PR DESCRIPTION
Hey @2pecshy!

This PR addresses issue #6. 

Between sending subsequent chunks of data the driver currently waits if the eeprom is not ready yet: 

https://github.com/2pecshy/eeprom-ST25DV-linux-driver/blob/ebf3d0ab7ea05d131bb65e4c614f86506851aa1e/src/st25dv.c#L188-L193

Unfortunately, the function currently returns right after sending the last chunk. This can cause issues if you try to read from the bus directly after a write operation.
Because of this I added a simple ACK polling before releasing the mutex and returning from the function.  

This is my first contribution on a linux driver codebase. I'm keen to get some feedback on this PR.